### PR TITLE
⭐ Update source objects by default

### DIFF
--- a/Modules/State/Source/init.luau
+++ b/Modules/State/Source/init.luau
@@ -406,6 +406,38 @@ function State.Interface.fromAttribute(object: Instance, attribute: string): Sta
 end
 
 --[=[
+	@function fromValue
+	@within State
+
+	@param object Instance & { Value: any? }
+
+	@return State
+
+	Wrapper for `State.new` however wraps around a Roblox Instance, the State object will always have the latest value.
+
+	```lua
+		local object = State.fromValue(workspace.object)
+
+		...
+	```
+]=]
+function State.Interface.fromValue(object: Instance & { Value: any? }): State
+	assert(object.Value, "instance must be a Value object!")
+
+	local stateObject = State.Interface.new(object.Value)
+
+	local valueConnection = object:GetPropertyChangedSignal("Value"):Connect(function()
+		stateObject:Set(object.Value)
+	end)
+
+	stateObject.Destroyed:Once(function()
+		valueConnection:Disconnect()
+	end)
+
+	return stateObject
+end
+
+--[=[
 	@function is
 	@within State
 

--- a/Modules/State/Source/init.luau
+++ b/Modules/State/Source/init.luau
@@ -119,6 +119,9 @@ end
 	```
 ]=]
 function State.Prototype:Destroy(): ()
+	self._instance = nil
+	self._fromAttributeName = nil
+	self._fromValue = nil
 	self._record = {}
 	self.Value = nil
 
@@ -165,13 +168,13 @@ function State.Prototype:Set(value: any, updateObject: boolean?): State
 	self.Value = value
 	self.Changed:Fire(value, oldValue)
 
-	if updateObject then
-		if self._fromAttribute then
-			self.Instance:SetAttribute(self.Attribute, value)
+	if updateObject and self._instance then
+		if self._fromAttributeName then
+			self._instance:SetAttribute(self._fromAttributeName, value)
 		end
 
 		if self._fromValue then
-			self.Instance.Value = value
+			self._instance.Value = value
 		end
 	end
 
@@ -404,7 +407,8 @@ end
 function State.Interface.fromAttribute(object: Instance, attribute: string): State
 	local attributeValue = object:GetAttribute(attribute)
 	local stateObject = State.Interface.new(attributeValue)
-	stateObject._fromAttribute = true
+	stateObject._fromAttributeName = attribute
+	stateObject._instance = object
 
 	local attributeConnections = {}
 
@@ -445,6 +449,7 @@ function State.Interface.fromValue(object: Instance & { Value: any? }): State
 
 	local stateObject = State.Interface.new(object.Value)
 	stateObject._fromValue = true
+	stateObject._instance = object
 
 	local valueConnection = object:GetPropertyChangedSignal("Value"):Connect(function()
 		stateObject:Set(object.Value)

--- a/Modules/State/Source/init.luau
+++ b/Modules/State/Source/init.luau
@@ -130,18 +130,26 @@ end
 	@within State
 
 	@param value any
+	@param updateObject boolean?
 
 	Set the value of a state, when setting a state the 'Changed' signal will invoke.
 
 	```lua
-		local Value = State.new(0)
+	local Value = State.new(0)
+	Value:Set(1)
+	```
 
-		Value:Set(1)
+	For state objects that are created using the `fromAttribute` or `fromValue` methods, the object will be updated with the new value. You can disable this by passing `false` for the `updateObject` parameter.
+
+	```lua
+	local Value = State.fromAttribute(workspace.object, "attributeName")
+	Value:Set(1, false)
 	```
 ]=]
-function State.Prototype:Set(value: any): State
-	local oldValue = self.Value
+function State.Prototype:Set(value: any, updateObject: boolean?): State
+	updateObject = if typeof(updateObject) == "boolean" then updateObject else true
 
+	local oldValue = self.Value
 	if oldValue == value then
 		return self
 	end
@@ -156,6 +164,16 @@ function State.Prototype:Set(value: any): State
 
 	self.Value = value
 	self.Changed:Fire(value, oldValue)
+
+	if updateObject then
+		if self._fromAttribute then
+			self.Instance:SetAttribute(self.Attribute, value)
+		end
+
+		if self._fromValue then
+			self.Instance.Value = value
+		end
+	end
 
 	return self
 end
@@ -386,6 +404,7 @@ end
 function State.Interface.fromAttribute(object: Instance, attribute: string): State
 	local attributeValue = object:GetAttribute(attribute)
 	local stateObject = State.Interface.new(attributeValue)
+	stateObject._fromAttribute = true
 
 	local attributeConnections = {}
 
@@ -425,6 +444,7 @@ function State.Interface.fromValue(object: Instance & { Value: any? }): State
 	assert(object.Value, "instance must be a Value object!")
 
 	local stateObject = State.Interface.new(object.Value)
+	stateObject._fromValue = true
 
 	local valueConnection = object:GetPropertyChangedSignal("Value"):Connect(function()
 		stateObject:Set(object.Value)


### PR DESCRIPTION
Requires review first: https://github.com/4x8Matrix/Package-Index/pull/20

Update source objects by default for State instances created with the `fromAttribute` or `fromValue` methods. Pass `updateObject = false` into the `State:Set(value, updateObject)` method to override this behaviour.